### PR TITLE
Added: FIT File Import: Option to set TourType to SportName from file

### DIFF
--- a/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/IPreferences.java
+++ b/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/IPreferences.java
@@ -29,4 +29,6 @@ public interface IPreferences {
 
    String FIT_PREFERRED_POWER_DATA_SOURCE    = "FIT_POWER_DATA_SOURCE";              //$NON-NLS-1$
 
+   String FIT_SPORT_NAME_FOR_TOUR_TYPE       = "FIT_SPORT_NAME_FOR_TOUR_TYPE";       //$NON-NLS-1$
+
 }

--- a/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/Messages.java
+++ b/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/Messages.java
@@ -11,11 +11,13 @@ public class Messages extends NLS {
    public static String        PrefPage_Fit_Checkbox_IgnoreLastMarker;
    public static String        PrefPage_Fit_Checkbox_IgnoreSpeedValues;
    public static String        PrefPage_Fit_Checkbox_ReplaceTimeSlice;
+   public static String        PrefPage_Fit_Checkbox_SportNameForTourType;
    public static String        PrefPage_Fit_Group_AdjustTemperature;
    public static String        PrefPage_Fit_Group_IgnoreLastMarker;
    public static String        PrefPage_Fit_Group_Power;
    public static String        PrefPage_Fit_Group_ReplaceTimeSlice;
    public static String        PrefPage_Fit_Group_Speed;
+   public static String        PrefPage_Fit_Group_SportName;
    public static String        PrefPage_Fit_Label_AdjustTemperature;
    public static String        PrefPage_Fit_Label_AdjustTemperature_Info;
    public static String        PrefPage_Fit_Label_IgnoreLastMarker_Info;
@@ -26,6 +28,8 @@ public class Messages extends NLS {
    public static String        PrefPage_Fit_Combo_Power_Data_Source_Garmin_RD_Pod;
    public static String        PrefPage_Fit_Label_ReplaceTimeSlice_Duration;
    public static String        PrefPage_Fit_Label_ReplaceTimeSlice_Info;
+   public static String        PrefPage_Fit_Label_SportNameForTourType_Info;
+
 
    static {
       // initialize resource bundle

--- a/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/PrefPageImportFit.java
+++ b/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/PrefPageImportFit.java
@@ -56,6 +56,7 @@ public class PrefPageImportFit extends PreferencePage implements IWorkbenchPrefe
    private static final int      TAB_FOLDER_MARKER_FILTER      = 2;
    private static final int      TAB_FOLDER_TIME_SLIZE         = 3;
    private static final int      TAB_FOLDER_POWER              = 4;
+   private static final int      TAB_FOLDER_SPORTNAME          = 5;
 
    private static PeriodType     _tourPeriodTemplate           = PeriodType.yearMonthDayTime()
 
@@ -79,12 +80,14 @@ public class PrefPageImportFit extends PreferencePage implements IWorkbenchPrefe
    private Button    _chkIgnoreLastMarker;
    private Button    _chkIgnoreSpeedValues;
    private Button    _chkRemoveExceededDuration;
+   private Button    _chkSportNameForTourType;
 
    private Combo     _comboPowerDataSource;
 
    private Label     _lblIgnorLastMarker_Info;
    private Label     _lblIgnorLastMarker_TimeSlices;
    private Label     _lblIgnorSpeedValues_Info;
+   private Label     _lblSportNameForTourType_Info;
    private Label     _lblSplitTour_Duration;
    private Label     _lblSplitTour_DurationUnit;
    private Label     _lblSplitTour_Info;
@@ -140,6 +143,10 @@ public class PrefPageImportFit extends PreferencePage implements IWorkbenchPrefe
             final TabItem tabPower = new TabItem(_tabFolder, SWT.NONE);
             tabPower.setControl(createUI_80_Power(_tabFolder));
             tabPower.setText(Messages.PrefPage_Fit_Group_Power);
+
+            final TabItem tabSportname = new TabItem(_tabFolder, SWT.NONE);
+            tabSportname.setControl(createUI_90_SportName(_tabFolder));
+            tabSportname.setText(Messages.PrefPage_Fit_Group_SportName);
          }
       }
 
@@ -392,6 +399,36 @@ public class PrefPageImportFit extends PreferencePage implements IWorkbenchPrefe
       return container;
    }
 
+    private Composite createUI_90_SportName(final Composite parent) {
+
+        final Composite container = new Composite(parent, SWT.NONE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(container);
+        GridLayoutFactory
+                .fillDefaults()//
+                .numColumns(1)
+                .extendedMargins(5, 5, 15, 5)
+                .spacing(20, 5)
+                .applyTo(container);
+        {
+            /*
+             * Sport Name for Tour Type
+             */
+
+            // checkbox: use srpot name for tour type
+            _chkSportNameForTourType = new Button(container, SWT.CHECK);
+            _chkSportNameForTourType.setText(Messages.PrefPage_Fit_Checkbox_SportNameForTourType);
+            _chkSportNameForTourType.addSelectionListener(_defaultSelectionListener);
+        }
+
+        {
+            // label: info
+            _lblSportNameForTourType_Info = createUI_InfoLabel(container, 3);
+            _lblSportNameForTourType_Info.setText(Messages.PrefPage_Fit_Label_SportNameForTourType_Info);
+        }
+
+        return container;
+    }
+
    private Label createUI_InfoLabel(final Composite parent, final int horizontalSpan) {
 
       final Label lblInfo = new Label(parent, SWT.WRAP);
@@ -411,6 +448,7 @@ public class PrefPageImportFit extends PreferencePage implements IWorkbenchPrefe
       final boolean isSplitTour = _chkRemoveExceededDuration.getSelection();
       final boolean isIgnoreSpeed = _chkIgnoreSpeedValues.getSelection();
       final boolean isIgnorLastMarker = _chkIgnoreLastMarker.getSelection();
+      final boolean isSportNameForTourType = _chkSportNameForTourType.getSelection();
 
       _lblIgnorSpeedValues_Info.setEnabled(isIgnoreSpeed);
 
@@ -422,6 +460,8 @@ public class PrefPageImportFit extends PreferencePage implements IWorkbenchPrefe
       _lblSplitTour_Duration.setEnabled(isSplitTour);
       _lblSplitTour_Info.setEnabled(isSplitTour);
       _spinnerExceededDuration.setEnabled(isSplitTour);
+
+      _lblSportNameForTourType_Info.setEnabled(isSportNameForTourType);
 
       updateUI_SplitTour();
    }
@@ -488,6 +528,9 @@ public class PrefPageImportFit extends PreferencePage implements IWorkbenchPrefe
       } else if (selectedTab == TAB_FOLDER_POWER) {
 
          _comboPowerDataSource.select(_prefStore.getDefaultInt(IPreferences.FIT_PREFERRED_POWER_DATA_SOURCE));
+      } else if (selectedTab == TAB_FOLDER_SPORTNAME) {
+
+         _chkSportNameForTourType.setSelection(_prefStore.getDefaultBoolean(IPreferences.FIT_SPORT_NAME_FOR_TOUR_TYPE));
       }
 
       enableControls();
@@ -535,6 +578,9 @@ public class PrefPageImportFit extends PreferencePage implements IWorkbenchPrefe
       // Preferred power data source
       _comboPowerDataSource.select(_prefStore.getInt(IPreferences.FIT_PREFERRED_POWER_DATA_SOURCE));
 
+      // Sport Name -> Tour Type
+      _chkSportNameForTourType.setSelection(_prefStore.getBoolean(IPreferences.FIT_SPORT_NAME_FOR_TOUR_TYPE));
+
       enableControls();
    }
 
@@ -569,6 +615,11 @@ public class PrefPageImportFit extends PreferencePage implements IWorkbenchPrefe
       _prefStore.setValue(
             IPreferences.FIT_PREFERRED_POWER_DATA_SOURCE,
             _comboPowerDataSource.getSelectionIndex());
+
+      // Sport Name -> Tour Type
+      _prefStore.setValue(
+            IPreferences.FIT_SPORT_NAME_FOR_TOUR_TYPE,
+            _chkSportNameForTourType.getSelection());
    }
 
    private void saveUIState() {

--- a/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/PreferenceInitializer.java
+++ b/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/PreferenceInitializer.java
@@ -38,6 +38,8 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
       store.setDefault(IPreferences.FIT_EXCEEDED_TIME_SLICE_DURATION, 365 * 24 * 60 * 60);
 
       store.setDefault(IPreferences.FIT_PREFERRED_POWER_DATA_SOURCE, 0);
+
+      store.setDefault(IPreferences.FIT_SPORT_NAME_FOR_TOUR_TYPE, false);
    }
 
 }

--- a/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/listeners/MesgListener_Session.java
+++ b/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/listeners/MesgListener_Session.java
@@ -62,6 +62,7 @@ public class MesgListener_Session extends AbstractMesgListener implements Sessio
       final Sport sport = mesg.getSport();
       if (sport != null) {
          tourData.setDeviceModeName(sport.name());
+         fitData.setSportname(sport.name());
       }
 
       final Short avgHeartRate = mesg.getAvgHeartRate();

--- a/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/messages.properties
+++ b/bundles/net.tourbook.device.garmin.fit/src/net/tourbook/device/garmin/fit/messages.properties
@@ -5,6 +5,7 @@ Import_Error_TourMarkerLabel_ExceededTimeSlice = This is an exceeded time slice,
 PrefPage_Fit_Checkbox_IgnoreLastMarker             = &Ignore tour markers at the end of the tour
 PrefPage_Fit_Checkbox_IgnoreSpeedValues            = Do not import s&peed values
 PrefPage_Fit_Checkbox_ReplaceTimeSlice             = &Replace time slices when &exceeding a longer duration
+PrefPage_Fit_Checkbox_SportNameForTourType         = Set &Tour Type to Sport Name field
 PrefPage_Fit_Combo_Power_Data_Source_Garmin_RD_Pod = Garmin Running Dynamics Pod
 PrefPage_Fit_Combo_Power_Data_Source_Stryd         = Stryd
 PrefPage_Fit_Group_AdjustTemperature               = Temperature
@@ -12,6 +13,7 @@ PrefPage_Fit_Group_IgnoreLastMarker                = Tour Marker Filter
 PrefPage_Fit_Group_Power                           = Power
 PrefPage_Fit_Group_ReplaceTimeSlice                = Exceeded Time Slice
 PrefPage_Fit_Group_Speed                           = Speed
+PrefPage_Fit_Group_SportName                       = SportName
 PrefPage_Fit_Label_AdjustTemperature               = Rectify &temperature
 PrefPage_Fit_Label_AdjustTemperature_Info          = This value will be added to each imported temperature value.\n\
                                                      \n\
@@ -25,6 +27,7 @@ PrefPage_Fit_Label_IgnoreLastMarker_TimeSlices     = Time slices
 PrefPage_Fit_Label_IgnoreSpeedValues_Info          = Speed values can be computed from time and distance.\n\
                                                      \n\
                                                      When this feature is selected, then speed values within FIT data will be ignored, this will save diskspace.
+PrefPage_Fit_Label_SportNameForTourType_Info       = When this feature is selected, Tour Type will be set to the Sport Name from the imported FIT file (ex: CYCLING, RUNNING, etc).
 PrefPage_Fit_Label_Preferred_Power_Data_Source     = &Preferred Power Data Source
 PrefPage_Fit_Label_ReplaceTimeSlice_Duration       = Exceeded duration (seconds)
 PrefPage_Fit_Label_ReplaceTimeSlice_Info           = When a time slice is exceeding the selected duration then this time slice will be replaced with a 1 second time slice, this will also adjust the \

--- a/info/release-notes/20.month.0-readme.txt
+++ b/info/release-notes/20.month.0-readme.txt
@@ -36,6 +36,9 @@ New + Improvements
 Import
 ======
 
+* FIT File (bbbbbr)
+  - Added option to set Tour Type using Sport Name from the
+    imported file
 
  
 Changes  


### PR DESCRIPTION
Hello,

Not sure if there is a standard process for a pull request on this project- so let me know if any changes need to be made to meet code standards and pull request information, or if there would be a more appropriate way to implement this feature.

I've added a feature to set the Tour Type based on the "Sport Name" when importing from Garmin FIT Files (useful to me, perhaps for others too). There is a preferences panel checkbox to control the behavior (it is turned off by default).

It is related to this feature request I opened:
https://sourceforge.net/p/mytourbook/feature-requests/158/

Thanks!
